### PR TITLE
Add feature for bulk file de-tokenisation

### DIFF
--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -17,7 +17,7 @@ $zerofailedExtensions = @(
 
 # Set the required build options
 $PesterTestsDir = "$here/module"
-$PesterVersion = "5.5.0"
+$PesterVersion = "5.7.1"
 $PowerShellModulesToPublish = @(
     @{
         ModulePath = "$here/module/ZeroFailed.DevOps.Common.psd1"

--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,40 @@
+# ZeroFailed.DevOps.Common - Reference Sheet
+
+## CI/CD Server
+
+This group contains functionality related to CI/CD platform integration, currently supports Azure DevOps and GitHub Actions.
+
+### Properties
+
+| Name                  | Description                                                                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| IsAzureDevOps         | Will be set to True when running in Azure DevOps (YAML pipeline or Classic release pipeline). ***NOTE**: Considered a read only property.* |
+| IsAzureDevOpsRelease  | Will be set to True when running in an Azure DevOps Classic release pipeline. ***NOTE**: Considered a read only property.*                 |
+| IsGitHubActions       | Will be set to True when running in a GitHub Actions workflow. ***NOTE**: Considered a read only property.*                                |
+| IsRunningOnCICDServer | Will be set to True when a supported CI/CD server platform is detected. ***NOTE**: Considered a read only property.*                       |
+| SkipDetectCICDServer  | When true, no DevOps agent detection will be attempted. Default is false.                                                                  |
+
+### Tasks
+
+| Name             | Description                                                             |
+| ---------------- | ----------------------------------------------------------------------- |
+| DetectCICDServer | Identifies which, if any, CI/CD platform is running the current process |
+
+## Common
+
+This group contains general purposes helper tasks, potentially useful for a wide range of DevOps processes.
+
+### Properties
+
+| Name                             | Description                                                                                                                                                              |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| RequiredPowerShellModules        | A hashtable of PowerShell modules to install and import. The keys are the module names and the values are hashtables with the following properties: version, repository. |
+| SkipEnsureGitHubCli              | When true, ZeroFailed will skip the check for whether the GitHub CLI is installed. Default is true.                                                                      |
+| SkipZeroFailedModuleVersionCheck | When true, ZeroFailed will skip the check for a newer version of the ZeroFailed module. Default is false.                                                                |
+
+### Tasks
+
+| Name            | Description                                                                                                            |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| EnsureGitHubCli | Checks that the GitHub CLI is installed and installs it if not.                                                        |
+| setupModules    | Installs and imports the specified PowerShell modules. ***NOTE**: PowerShell repositories will be trusted by default.* |

--- a/HELP.md
+++ b/HELP.md
@@ -6,19 +6,19 @@ This group contains functionality related to CI/CD platform integration, current
 
 ### Properties
 
-| Name                  | Description                                                                                                                                |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| IsAzureDevOps         | Will be set to True when running in Azure DevOps (YAML pipeline or Classic release pipeline). ***NOTE**: Considered a read only property.* |
-| IsAzureDevOpsRelease  | Will be set to True when running in an Azure DevOps Classic release pipeline. ***NOTE**: Considered a read only property.*                 |
-| IsGitHubActions       | Will be set to True when running in a GitHub Actions workflow. ***NOTE**: Considered a read only property.*                                |
-| IsRunningOnCICDServer | Will be set to True when a supported CI/CD server platform is detected. ***NOTE**: Considered a read only property.*                       |
-| SkipDetectCICDServer  | When true, no DevOps agent detection will be attempted. Default is false.                                                                  |
+| Name                    | Default Value | ENV Override                 | Description                                                                                                                                |
+| ----------------------- | ------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `IsAzureDevOps`         | $false        |                              | Will be set to True when running in Azure DevOps (YAML pipeline or Classic release pipeline). ***NOTE**: Considered a read only property.* |
+| `IsAzureDevOpsRelease`  | $false        |                              | Will be set to True when running in an Azure DevOps Classic release pipeline. ***NOTE**: Considered a read only property.*                 |
+| `IsGitHubActions`       | $false        |                              | Will be set to True when running in a GitHub Actions workflow. ***NOTE**: Considered a read only property.*                                |
+| `IsRunningOnCICDServer` | $false        |                              | Will be set to True when a supported CI/CD server platform is detected. ***NOTE**: Considered a read only property.*                       |
+| `SkipDetectCICDServer`  | $false        | `ZF_SKIP_DETECT_CICD_SERVER` | When true, no DevOps agent detection will be attempted. Default is false.                                                                  |
 
 ### Tasks
 
-| Name             | Description                                                             |
-| ---------------- | ----------------------------------------------------------------------- |
-| DetectCICDServer | Identifies which, if any, CI/CD platform is running the current process |
+| Name               | Description                                                             |
+| ------------------ | ----------------------------------------------------------------------- |
+| `DetectCICDServer` | Identifies which, if any, CI/CD platform is running the current process |
 
 ## Common
 
@@ -26,15 +26,15 @@ This group contains general purposes helper tasks, potentially useful for a wide
 
 ### Properties
 
-| Name                             | Description                                                                                                                                                              |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| RequiredPowerShellModules        | A hashtable of PowerShell modules to install and import. The keys are the module names and the values are hashtables with the following properties: version, repository. |
-| SkipEnsureGitHubCli              | When true, ZeroFailed will skip the check for whether the GitHub CLI is installed. Default is true.                                                                      |
-| SkipZeroFailedModuleVersionCheck | When true, ZeroFailed will skip the check for a newer version of the ZeroFailed module. Default is false.                                                                |
+| Name                               | Default Value | ENV Override                              | Description                                                                                                                                                              |
+| ---------------------------------- | ------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `RequiredPowerShellModules`        | @{}           | `ZF_REQUIRED_PS_MODULES`                  | A hashtable of PowerShell modules to install and import. The keys are the module names and the values are hashtables with the following properties: version, repository. |
+| `SkipEnsureGitHubCli`              | $true         | `ZF_SKIP_ENSURE_GITHUB_CLI`               | When true, ZeroFailed will skip the check for whether the GitHub CLI is installed. Default is true.                                                                      |
+| `SkipZeroFailedModuleVersionCheck` | $false        | `ZF_SKIP_ZEROFAILED_MODULE_VERSION_CHECK` | When true, ZeroFailed will skip the check for a newer version of the ZeroFailed module. Default is false.                                                                |
 
 ### Tasks
 
-| Name            | Description                                                                                                            |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| EnsureGitHubCli | Checks that the GitHub CLI is installed and installs it if not.                                                        |
-| setupModules    | Installs and imports the specified PowerShell modules. ***NOTE**: PowerShell repositories will be trusted by default.* |
+| Name              | Description                                                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `EnsureGitHubCli` | Checks that the GitHub CLI is installed and installs it if not.                                                        |
+| `setupModules`    | Installs and imports the specified PowerShell modules. ***NOTE**: PowerShell repositories will be trusted by default.* |

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A [ZeroFailed](https://github.com/zerofailed/ZeroFailed) extension containing ge
 
 For more information about the different component types, please refer to the [ZeroFailed documentation](https://github.com/zerofailed/ZeroFailed/blob/main/README.md#extensions).
 
-This extension consists of the following feature groups, click the links to see their documentation:
+This extension consists of the following feature groups, refer to the [HELP page](./HELP.md) for more details.
 
-- Miscellaneous environment checks
+- General purpose helper tasks
 - CI/CD Server integration
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The diagram below shows the discrete features and when they run as part of the d
 kanban
     init
         ensureghcli[Ensure 'gh' cli installed]
+    version
     build
     test
     analysis

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A [ZeroFailed](https://github.com/zerofailed/ZeroFailed) extension containing ge
 |----------------|----------|---------------------|
 | Tasks          | yes      | |
 | Functions      | yes      | |
-| Processes      | no       | |
+| Processes      | no       | Designed to be compatible with upstream processes provided by the [ZeroFailed.Build.Common](https://github.com/zerofailed/ZeroFailed.Build.Common) & [ZeroFailed.Deploy.Common](https://github.com/zerofailed/ZeroFailed.Deploy.Common) extensions |
 
 For more information about the different component types, please refer to the [ZeroFailed documentation](https://github.com/zerofailed/ZeroFailed/blob/main/README.md#extensions).
 
@@ -23,6 +23,32 @@ This extension consists of the following feature groups, refer to the [HELP page
 - General purpose helper tasks
 - CI/CD Server integration
 
+The diagram below shows the discrete features and when they run as part of the default build process provided by [ZeroFailed.Build.Common](https://github.com/zerofailed/ZeroFailed.Build.Common).
+
+```mermaid
+kanban
+    init
+        ensureghcli[Ensure 'gh' cli installed]
+    build
+    test
+    analysis
+    package
+    publish
+```
+
+This diagram below shows the same for the default deployment process provided by [ZeroFailed.Deploy.Common](https://github.com/zerofailed/ZeroFailed.Deploy.Common).
+
+```mermaid
+kanban
+    init
+        ensureghcli[Ensure 'gh' cli installed]
+    provision
+    deploy
+    test
+```
+
 ## Dependencies
 
 None.
+
+***NOTE**: This extension is widely referenced and is typically the root dependency for other ZeroFailed extensions.*

--- a/module/functions/Edit-TokenizedFiles.Tests.ps1
+++ b/module/functions/Edit-TokenizedFiles.Tests.ps1
@@ -10,6 +10,8 @@ BeforeAll {
     
     Mock Write-Host {}
     Mock Write-Verbose {}
+
+    $defaultTokenRegexPattern = "\#\{.*\}\#"
 }
 
 Describe "Edit-TokenizedFiles Tests" {
@@ -17,8 +19,6 @@ Describe "Edit-TokenizedFiles Tests" {
     Context "Single File: Using the default TokenRegexPattern" {
 
         BeforeAll {
-            $defaultTokenRegexPattern = "\#\{.*\}\#"
-
             $testJsonConfig = @"
 {
     "settingA": "#{SETTING_A}#",
@@ -68,6 +68,77 @@ Describe "Edit-TokenizedFiles Tests" {
 
         It "should handle multiple tokens referenced on the same line correctly" {
             (Get-Content -Raw -Path $testJsonFile | ConvertFrom-Json).settingC | Should -Be "foo__bar"
+        }
+    }
+
+    Context "Multiple Files: Using the default TokenRegexPattern" {
+
+        BeforeAll {
+
+            $testJsonConfig = @"
+{
+    "settingA": "#{SETTING_A}#",
+    "settingB": "B",
+    "settingC": "#{SETTING_A}#__#{SETTING_B}#"
+}    
+"@
+            $testJsonFile = "TestDrive:/test-config.json"
+            Set-Content -Path $testJsonFile -Value $testJsonConfig
+
+            $testPsd1Config = @"
+@{
+    settingA = '#{SETTING_A}#'
+    settingB = 'B'
+    settingC = '#{SETTING_A}#__#{SETTING_B}#'
+}
+"@
+            $testPsd1File = "TestDrive:/test-config.psd1"
+            Set-Content -Path $testPsd1File -Value $testPsd1Config
+    
+            $tokenValues = @{
+                SETTING_A = "foo"
+                SETTING_B = "bar"
+            }
+        }
+        
+        BeforeEach {
+            Edit-TokenizedFiles -FilesToProcess @($testJsonFile,$testPsd1File) `
+                                -TokenValuePairs $tokenValues
+        }
+
+        It "should parse the tokens in the target file correctly" {
+            # Uses logging calls to verify execution behaviour
+
+            # Messages for the 2 token replacements and the file save operation
+            Should -Invoke Write-Host -Exactly 6
+
+            # verify processing the correct number of tokens
+            Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Checking for SETTING_A" } -Exactly 1
+            Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Checking for SETTING_B" } -Exactly 1
+            
+            # verify expected tokens were processed
+            Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_A' in 'TestDrive:/test-config.json'") } -Exactly 1
+            Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_B' in 'TestDrive:/test-config.json'") } -Exactly 1
+            Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_A' in 'TestDrive:/test-config.psd1'") } -Exactly 1
+            Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_B' in 'TestDrive:/test-config.psd1'") } -Exactly 1
+
+            # verify all tokens were found
+            Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Token not found" } -Exactly 0
+        }
+
+        It "should replace the required token" {
+            (Get-Content -Raw -Path $testJsonFile) -match $defaultTokenRegexPattern | Should -Be $false
+            (Get-Content -Raw -Path $testPsd1File) -match $defaultTokenRegexPattern | Should -Be $false
+        }
+
+        It "should replace the required token with the correct value" {
+            (Get-Content -Raw -Path $testJsonFile | ConvertFrom-Json).settingA | Should -Be "foo"
+            (Import-PowerShellDataFile -Path $testPsd1File).settingA | Should -Be "foo"
+        }
+
+        It "should handle multiple tokens referenced on the same line correctly" {
+            (Get-Content -Raw -Path $testJsonFile | ConvertFrom-Json).settingC | Should -Be "foo__bar"
+            (Import-PowerShellDataFile -Path $testPsd1File).settingC | Should -Be "foo__bar"
         }
     }
 }

--- a/module/functions/Edit-TokenizedFiles.Tests.ps1
+++ b/module/functions/Edit-TokenizedFiles.Tests.ps1
@@ -1,0 +1,73 @@
+# <copyright file="Edit-TokenizedFiles.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    $sut = (Split-Path -Leaf $PSCommandPath) -replace ".Tests"
+    
+    . "$here\$sut"
+    
+    Mock Write-Host {}
+    Mock Write-Verbose {}
+}
+
+Describe "Edit-TokenizedFiles Tests" {
+
+    Context "Single File: Using the default TokenRegexPattern" {
+
+        BeforeAll {
+            $defaultTokenRegexPattern = "\#\{.*\}\#"
+
+            $testJsonConfig = @"
+{
+    "settingA": "#{SETTING_A}#",
+    "settingB": "B",
+    "settingC": "#{SETTING_A}#__#{SETTING_B}#"
+}    
+"@
+            $testJsonFile = "TestDrive:/test-config.json"
+            Set-Content -Path $testJsonFile -Value $testJsonConfig
+    
+            $tokenValues = @{
+                SETTING_A = "foo"
+                SETTING_B = "bar"
+            }
+        }
+        
+        BeforeEach {
+            Edit-TokenizedFiles -FilesToProcess @($testJsonFile) `
+                                -TokenValuePairs $tokenValues
+        }
+
+        It "should parse the tokens in the target file correctly" {
+            # Uses logging calls to verify execution behaviour
+
+            # Messages for the 2 token replacements and the file save operation
+            Should -Invoke Write-Host -Exactly 3
+
+            # verify processing the correct number of tokens
+            Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Checking for SETTING_A" } -Exactly 1
+            Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Checking for SETTING_B" } -Exactly 1
+            
+            # verify expected tokens were processed
+            Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_A'") } -Exactly 1
+            Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_B'") } -Exactly 1
+
+            # verify all tokens were found
+            Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Token not found" } -Exactly 0
+        }
+
+        It "should replace the required token" {
+            (Get-Content -Raw -Path $testJsonFile) -match $defaultTokenRegexPattern | Should -Be $false
+        }
+
+        It "should replace the required token with the correct value" {
+            (Get-Content -Raw -Path $testJsonFile | ConvertFrom-Json).settingA | Should -Be "foo"
+        }
+
+        It "should handle multiple tokens referenced on the same line correctly" {
+            (Get-Content -Raw -Path $testJsonFile | ConvertFrom-Json).settingC | Should -Be "foo__bar"
+        }
+    }
+}

--- a/module/functions/Edit-TokenizedFiles.Tests.ps1
+++ b/module/functions/Edit-TokenizedFiles.Tests.ps1
@@ -23,7 +23,7 @@ Describe "Edit-TokenizedFiles Tests" {
 {
     "settingA": "#{SETTING_A}#",
     "settingB": "B",
-    "settingC": "#{SETTING_A}#__#{SETTING_B}#"
+    "settingC": "#{SETTING_A}#__#{SETTING_B}#__#{SETTING_C}#"
 }    
 "@
             $testJsonFile = "TestDrive:/test-config.json"
@@ -32,6 +32,7 @@ Describe "Edit-TokenizedFiles Tests" {
             $tokenValues = @{
                 SETTING_A = "foo"
                 SETTING_B = "bar"
+                SETTING_C = "too_far"
             }
         }
         
@@ -43,16 +44,18 @@ Describe "Edit-TokenizedFiles Tests" {
         It "should parse the tokens in the target file correctly" {
             # Uses logging calls to verify execution behaviour
 
-            # Messages for the 2 token replacements and the file save operation
-            Should -Invoke Write-Host -Exactly 3
+            # Messages for the 3 token replacements and the file save operation
+            Should -Invoke Write-Host -Exactly 4
 
             # verify processing the correct number of tokens
             Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Checking for SETTING_A" } -Exactly 1
             Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Checking for SETTING_B" } -Exactly 1
+            Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Checking for SETTING_C" } -Exactly 1
             
             # verify expected tokens were processed
             Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_A'") } -Exactly 1
             Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_B'") } -Exactly 1
+            Should -Invoke Write-Host -ParameterFilter { $Object.StartsWith("Patching 'SETTING_C'") } -Exactly 1
 
             # verify all tokens were found
             Should -Invoke Write-Verbose -ParameterFilter { $Message -eq "Token not found" } -Exactly 0
@@ -67,7 +70,7 @@ Describe "Edit-TokenizedFiles Tests" {
         }
 
         It "should handle multiple tokens referenced on the same line correctly" {
-            (Get-Content -Raw -Path $testJsonFile | ConvertFrom-Json).settingC | Should -Be "foo__bar"
+            (Get-Content -Raw -Path $testJsonFile | ConvertFrom-Json).settingC | Should -Be "foo__bar__too_far"
         }
     }
 

--- a/module/functions/Edit-TokenizedFiles.ps1
+++ b/module/functions/Edit-TokenizedFiles.ps1
@@ -1,0 +1,94 @@
+# <copyright file="Edit-TokenizedFiles.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+    Searches multiple files for occurrences of multiple strings following a regular expression pattern and replaces them with the provided values.
+.DESCRIPTION
+    Configuration that changes between different environments etc. is often represented by a tokenised value, which is updated before use.
+    For example, consider a file containing the following:
+
+    {
+        "apiBaseUrl": "https://#{ApiServer}#/api"
+    }
+
+    This function allows such tokenised files to be easily updated with their actual values based on the configuration passed in the 'TokenValuePairs'
+    hashtable.
+
+    Using the following hashtable:
+
+    @{
+        ApiServer = "myserver.nowhere.org"
+    }
+
+    Would result in the file being updated as shown below:
+
+    {
+        "apiBaseUrl": "https://myserver.nowhere.org/api"
+    }
+.PARAMETER FilesToProcess
+    The array of files to be processed.
+.PARAMETER TokenRegexFormatString
+    The regular expression used to locate tokens to be replaced. The expression must contain a single
+    format string placeholder (i.e. '{0}') to represent the name of the token. Defaults to an
+    expression suitable for use with the above example.
+.PARAMETER TokenValuePairs
+    A hashtable containing the mapping of tokens to their respective values.
+.EXAMPLE
+    TODO
+.NOTES
+    NOTE: When customising the 'TokenRegexFormatString', care must be taken to ensure that any characters
+    that would other conflict with the format string syntax are suitably escaped.
+    
+    For example, the pattern used above requires the braces to be escaped: "\#\{{{0}\}}\#"
+
+    - Regex syntax requires '#', '{' and '}' need to be escaped with the backslash
+    - Format string syntax requires the '{' and '}' not related to the format string to be escaped by doubling them up
+#>
+function Edit-TokenizedFiles
+{
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [string[]] $FilesToProcess,
+        [string] $TokenRegexFormatString = "\#\{{{0}\}}\#",     # the escaped curly brackets need to be doubled-up to work properly with the format string
+        [hashtable] $TokenValuePairs
+    )
+
+    $configCache = @{}
+    $FilesToProcess | ForEach-Object {
+        Write-Verbose "Caching file: $_"
+        $configCache += @{ 
+            $_ = @{
+                contents = (Get-Content -Raw $_)
+                updated = $false
+            }
+        }
+    }
+
+    $TokenValuePairs.Keys | ForEach-Object {
+        $token = $_
+        $regexPattern = $TokenRegexFormatString -f $token
+        Write-Verbose "Checking for $token"
+        $configCache.Keys | ForEach-Object {
+            if ($configCache[$_].contents -match $regexPattern) {
+                Write-Host "Patching '$token' in '$_'"
+                $configCache[$_].updated = $true
+                $configCache[$_].contents = $configCache[$_].contents -replace $regexPattern,$TokenValuePairs[$token]
+            }
+            else {
+                Write-Verbose "Token not found"
+            }
+        }
+    }
+
+    $configCache.Keys |
+        Where-Object { $configCache[$_].updated } |
+        ForEach-Object {
+            if ($PSCmdlet.ShouldProcess($_)) {
+                Write-Host "Saving '$_'"
+                Set-Content -Path $_ `
+                            -Value $configCache[$_].contents
+            }
+        }
+}

--- a/module/tasks/cicd-server.properties.ps1
+++ b/module/tasks/cicd-server.properties.ps1
@@ -2,10 +2,17 @@
 # Copyright (c) Endjin Limited. All rights reserved.
 # </copyright>
 
-# Internal properties not intended for external modification
+
+# Synopsis: Will be set to True when a supported CI/CD server platform is detected. ***NOTE**: Considered a read only property.*
 $IsRunningOnCICDServer = $false
+
+# Synopsis: Will be set to True when running in Azure DevOps (YAML pipeline or Classic release pipeline). ***NOTE**: Considered a read only property.*
 $IsAzureDevOps = $false
+
+# Synopsis: Will be set to True when running in an Azure DevOps Classic release pipeline. ***NOTE**: Considered a read only property.*
 $IsAzureDevOpsRelease = $false
+
+# Synopsis: Will be set to True when running in a GitHub Actions workflow. ***NOTE**: Considered a read only property.*
 $IsGitHubActions = $false
 
 # Synopsis: When true, no DevOps agent detection will be attempted. Default is false.

--- a/module/tasks/common.tasks.ps1
+++ b/module/tasks/common.tasks.ps1
@@ -17,7 +17,7 @@ task EnsureGitHubCli -If { !$SkipEnsureGitHubCli } -After InitCore {
     }
 }
 
-# Synopsis: Installs and imports the specified PowerShell modules. NOTE: PowerShell repositories will be trusted by default.
+# Synopsis: Installs and imports the specified PowerShell modules. ***NOTE**: PowerShell repositories will be trusted by default.*
 task setupModules -If { $null -ne $RequiredPowerShellModules -and $RequiredPowerShellModules -ne @{} } {
     Install-PSResource -RequiredResource $RequiredPowerShellModules -Scope CurrentUser -TrustRepository | Out-Null
     $RequiredPowerShellModules.Keys | ForEach-Object { Import-Module $_ }


### PR DESCRIPTION
Adds the `Edit-TokenizedFiles` command that can process multiple files to replaced tokenised values in a single batch operation.

Default convention is to format these placeholders using the `#{SOME_KEY}#` pattern.  Here is a JSON file example:
```
{
    "settingA": "#{SETTING_A}#",
    "settingB": "B",
    "settingC": "#{SETTING_C}#"
} 
``` 

Replacement values are passed as a hashtable:
```
@{
  settingA = 'some value'
  settingC = 'another value'
}
```

Also updates the repo documentation