### PR TITLE
Add support for running `gilt`

### DIFF
--- a/module/tasks/common.properties.ps1
+++ b/module/tasks/common.properties.ps1
@@ -13,6 +13,21 @@ $SkipEnsureGitHubCli = [Convert]::ToBoolean((property ZF_SKIP_ENSURE_GITHUB_CLI 
 # Synopsis: A hashtable of PowerShell modules to install and import. The keys are the module names and the values are hashtables with the following properties: version, repository.
 $RequiredPowerShellModules = property ZF_REQUIRED_PS_MODULES @{}
 
+# Synopsis: When false, the 'gilt' tool will be run if an associated configuration file can be found.
+$SkipRunGilt = [Convert]::ToBoolean((property ZF_SKIP_RUN_GILT $false))
+
+# Synopsis: The path to the 'gilt' configuration file.
+$GiltConfigPath = property ZF_GILT_CONFIG_PATH (Join-Path $here 'Giltfile.yaml')
+
+# Synopsis: The path to the 'gilt' tool.
+$GiltPath = property ZF_GILT_TOOL_PATH 'gilt'
+
+# Synopsis: The version of 'gilt' that will be installed when not already available.
+$GiltVersion = property ZF_GILT_VERSION '2.2.4'
+
+# Synopsis: When true, the 'gilt' tool will be installed even if it is already available.
+$ForceInstallGilt = [Convert]::ToBoolean((property ZF_FORCE_INSTALL_GILT $false))
+
 # Synopsis: [Extensibility Point] A collection of scriptblocks that will be run as part of InvokeBuild's 'Enter-Build' functionality. Extensions and processes can register their own actions by calling `$script:OnEnterActions.Add($myScriptBlock)`.
 $OnEnterActions = [List[scriptblock]]::new()
 


### PR DESCRIPTION
[Gilt](https://retr0h.github.io/gilt/) provides a mechanism for copying files from other git repositories to the local filesystem (aka layering).

This PR enables:
- Detection of the `Giltfile.yaml` configuration file to trigger use of this new feature
- Installation of the `gilt` tool via GitHub release artifacts
- Running `gilt` to perform the layering

***NOTE**: Currently the Gilt project does not produce native Windows binaries as part of its releases, so currently we obtain these from a fork.*