### PR TITLE
Support running nested builds as 'Build-Enter' and 'Build-Exit' actions

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -14,5 +14,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "1.1"
+next-version: "2.0"
 

--- a/HELP.md
+++ b/HELP.md
@@ -56,10 +56,10 @@ This extension's `common.tasks.ps1` defines these hooks and uses them to iterate
 
 ### Properties
 
-| Name             | Default Value | ENV Override | Description                                                                                                                  |
-| ---------------- | ------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `OnEnterActions` | `@()`         |              | [Extensibility Point] A collection of scriptblocks run as part of InvokeBuild's `Enter-Build` hook at the start of a build. |
-| `OnExitActions`  | `@()`         |              | [Extensibility Point] A collection of scriptblocks run as part of InvokeBuild's `Exit-Build` hook at the end of a build. All registered actions are run even if a previous one fails. |
+| Name             | Default Value                                      | ENV Override | Description                                                                                                                  |
+| ---------------- | -------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `OnEnterActions` | `[System.Collections.Generic.List[scriptblock]]::new()` |              | [Extensibility Point] A collection of scriptblocks run as part of InvokeBuild's `Enter-Build` hook at the start of a build. |
+| `OnExitActions`  | `[System.Collections.Generic.List[scriptblock]]::new()` |              | [Extensibility Point] A collection of scriptblocks run as part of InvokeBuild's `Exit-Build` hook at the end of a build. All registered actions are run even if a previous one fails. |
 
 ### Functions
 

--- a/HELP.md
+++ b/HELP.md
@@ -41,3 +41,87 @@ This group contains general purposes helper tasks, potentially useful for a wide
 | `EnsureGitHubCli` | Checks that the GitHub CLI is installed and installs it if not.                                                        |
 | `setupModules`    | Installs and imports the specified PowerShell modules. ***NOTE**: PowerShell repositories will be trusted by default.* |
 
+## Build Lifecycle Hooks
+
+This extension exposes two extensibility points — `OnEnterActions` and `OnExitActions` — that allow any ZeroFailed process or extension module to register scriptblocks that are automatically invoked at the very start and very end of a build, respectively. This is the recommended way to implement startup initialisation and teardown/compensation logic that should run regardless of whether the build succeeds or fails.
+
+### InvokeBuild background
+
+InvokeBuild provides two special hooks — [`Enter-Build`](https://github.com/nightroman/Invoke-Build/blob/main/README.md#enter-build-and-exit-build) and [`Exit-Build`](https://github.com/nightroman/Invoke-Build/blob/main/README.md#enter-build-and-exit-build) — that are called once per build run, outside of any task:
+
+- **`Enter-Build`** runs once before the first task. Errors raised here will abort the build.
+- **`Exit-Build`** runs once after the last task (or after an error), making it equivalent to a `finally` block for the entire build.
+
+This extension's `common.tasks.ps1` defines these hooks and uses them to iterate the `$OnEnterActions` and `$OnExitActions` collections, meaning any registered actions are automatically invoked at the correct point without requiring consumers to define their own hooks.
+
+### Properties
+
+| Name             | Default Value | ENV Override | Description                                                                                                                  |
+| ---------------- | ------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `OnEnterActions` | `@()`         |              | [Extensibility Point] A collection of scriptblocks run as part of InvokeBuild's `Enter-Build` hook at the start of a build. |
+| `OnExitActions`  | `@()`         |              | [Extensibility Point] A collection of scriptblocks run as part of InvokeBuild's `Exit-Build` hook at the end of a build. All registered actions are run even if a previous one fails. |
+
+### Functions
+
+| Name                    | Description                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `Register-OnEnterAction` | Registers a scriptblock to be run as part of the `Enter-Build` hook. Safe to call from extension modules and build scripts.         |
+| `Register-OnExitAction`  | Registers a scriptblock to be run as part of the `Exit-Build` hook. Safe to call from extension modules and build scripts.          |
+
+### How to use in your own ZeroFailed process
+
+#### Registering a simple scriptblock
+
+Call `Register-OnEnterAction` or `Register-OnExitAction` with a scriptblock argument. The scriptblock will be queued and run at the appropriate point in the build lifecycle.
+
+```powershell
+# Run something at the start of every build
+Register-OnEnterAction -Action {
+    Write-Build White 'Initialising environment...'
+    Set-SomeGlobalState
+}
+
+# Run cleanup unconditionally at the end of every build
+Register-OnExitAction -Action {
+    Write-Build White 'Cleaning up temporary resources...'
+    Remove-TempResources
+}
+```
+
+#### Running a nested build as an action
+
+Actions are not limited to inline scriptblocks — you can invoke a full nested `Invoke-Build` run, allowing one or more InvokeBuild tasks to be used as lifecycle hooks. This is especially useful for extensions that ship their own task files.
+
+```powershell
+# Run a specific task from another build file as a startup action
+Register-OnEnterAction -Action {
+    Invoke-Build -File "$PSScriptRoot/my-extension.tasks.ps1" -Task MyStartupTask
+}
+
+# Run a cleanup task unconditionally at build exit
+Register-OnExitAction -Action {
+    Invoke-Build -File "$PSScriptRoot/my-extension.tasks.ps1" -Task MyCleanupTask
+}
+```
+
+#### Registering from an extension module
+
+When registering actions from within an extension module's task file, avoid referencing the  `OnEnterActions` / `OnExitActions` variables directly, instead using the helper functions to handle this as they apply additional safeguards.
+
+```powershell
+# In your extension's .tasks.ps1 file — preferred approach using the helper functions
+Register-OnEnterAction -Action { & "$PSScriptRoot/_internal/startup.ps1" }
+Register-OnExitAction  -Action { & "$PSScriptRoot/_internal/teardown.ps1" }
+```
+
+#### Error handling behaviour
+
+| Hook            | Behaviour on error                                                                                       |
+| --------------- | -------------------------------------------------------------------------------------------------------- |
+| `Enter-Build`   | An unhandled error in any Enter action will **abort the build** (default PowerShell error handling).     |
+| `Exit-Build`    | Each Exit action is called with `-ErrorAction Continue`, so **all registered actions always run**, even if a preceding action throws. Errors are reported but do not prevent subsequent actions from executing. |
+
+#### Re-entrancy protection
+
+When ZeroFailed executes a registered action it sets a guard variable (`$__RunningInEnterAction` or `$__RunningInExitAction`) in the action's child scope. The `Register-OnEnterAction` and `Register-OnExitAction` functions check for this variable and silently skip registration if it is set. This prevents infinite loops in the scenario where a nested `Invoke-Build` call inside an action would otherwise trigger a second round of action registration and execution.
+

--- a/docs/functions/Register-OnEnterAction.md
+++ b/docs/functions/Register-OnEnterAction.md
@@ -1,0 +1,84 @@
+---
+document type: cmdlet
+external help file: ZeroFailed.DevOps.Common-Help.xml
+HelpUri: ''
+Locale: en-GB
+Module Name: ZeroFailed.DevOps.Common
+ms.date: 04/24/2026
+PlatyPS schema version: 2024-05-01
+title: Register-OnEnterAction
+---
+
+# Register-OnEnterAction
+
+## SYNOPSIS
+
+A helper function for consumers to register a PowerShell script block run as part of the InvokeBuild `Enter-Build` extensibility point.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Register-OnEnterAction [-Action] <scriptblock> [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+A helper function for consumers to register a PowerShell script block run as part of the InvokeBuild `Enter-Build` extensibility point.
+
+## EXAMPLES
+
+### Example 1 - Simple script block
+
+Register-OnEnterAction -Action { Write-Build White 'Doing something' }
+
+### Example 2 - Running a nested build
+
+Register-OnEnterAction -Action { Invoke-Build -File my.tasks.ps1 -Task MyStartupTask }
+
+## PARAMETERS
+
+### -Action
+
+A script block containing the functionality that should run as part of the InvokeBuild `Enter-Build` extensibility point.
+
+```yaml
+Type: System.Management.Automation.ScriptBlock
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Void
+
+The function has no outputs.
+
+## NOTES
+
+## RELATED LINKS
+
+- []()

--- a/docs/functions/Register-OnExitAction.md
+++ b/docs/functions/Register-OnExitAction.md
@@ -1,0 +1,84 @@
+---
+document type: cmdlet
+external help file: ZeroFailed.DevOps.Common-Help.xml
+HelpUri: ''
+Locale: en-GB
+Module Name: ZeroFailed.DevOps.Common
+ms.date: 04/24/2026
+PlatyPS schema version: 2024-05-01
+title: Register-OnExitAction
+---
+
+# Register-OnExitAction
+
+## SYNOPSIS
+
+A helper function for consumers to register a PowerShell script block run as part of the InvokeBuild `Exit-Build` extensibility point.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```
+Register-OnExitAction [-Action] <scriptblock> [<CommonParameters>]
+```
+
+## ALIASES
+
+## DESCRIPTION
+
+A helper function for consumers to register a PowerShell script block run as part of the InvokeBuild `Exit-Build` extensibility point.
+
+## EXAMPLES
+
+### Example 1 - Simple script block
+
+Register-OnExitAction -Action { Write-Build White 'Doing some clena-up' }
+
+### Example 2 - Running a nested build
+
+Register-OnEnterAction -Action { Invoke-Build -File my.tasks.ps1 -Task MyCleanupTask }
+
+## PARAMETERS
+
+### -Action
+
+A script block containing the functionality that should run as part of the InvokeBuild `Exit-Build` extensibility point.
+
+```yaml
+Type: System.Management.Automation.ScriptBlock
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Void
+
+The function has no outputs.
+
+## NOTES
+
+## RELATED LINKS
+
+- []()

--- a/docs/functions/Register-OnExitAction.md
+++ b/docs/functions/Register-OnExitAction.md
@@ -37,7 +37,7 @@ Register-OnExitAction -Action { Write-Build White 'Doing some clena-up' }
 
 ### Example 2 - Running a nested build
 
-Register-OnEnterAction -Action { Invoke-Build -File my.tasks.ps1 -Task MyCleanupTask }
+Register-OnExitAction -Action { Invoke-Build -File my.tasks.ps1 -Task MyCleanupTask }
 
 ## PARAMETERS
 

--- a/docs/functions/Register-OnExitAction.md
+++ b/docs/functions/Register-OnExitAction.md
@@ -33,7 +33,7 @@ A helper function for consumers to register a PowerShell script block run as par
 
 ### Example 1 - Simple script block
 
-Register-OnExitAction -Action { Write-Build White 'Doing some clena-up' }
+Register-OnExitAction -Action { Write-Build White 'Doing some clean-up' }
 
 ### Example 2 - Running a nested build
 

--- a/module/functions/Register-OnEnterAction.Tests.ps1
+++ b/module/functions/Register-OnEnterAction.Tests.ps1
@@ -1,0 +1,58 @@
+# <copyright file="Register-OnEnterAction.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+BeforeAll {
+    # sut
+    . $PSCommandPath.Replace('.Tests.ps1','.ps1')
+}
+
+Describe 'Register-OnEnterAction' {
+
+    BeforeEach {
+        $script:OnEnterActions = [System.Collections.Generic.List[scriptblock]]::new()
+        Remove-Variable -Name __RunningInEnterAction -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    Context 'When the guard variable does not exist' {
+
+        It 'should add the action to the list' {
+            $action = { Write-Host 'action' }
+            Register-OnEnterAction -Action $action
+            $script:OnEnterActions.Count | Should -Be 1
+            $script:OnEnterActions[0] | Should -Be $action
+        }
+
+        It 'can register multiple actions' {
+            Register-OnEnterAction -Action { Write-Host 'action 1' }
+            Register-OnEnterAction -Action { Write-Host 'action 2' }
+            $script:OnEnterActions.Count | Should -Be 2
+        }
+    }
+
+    Context 'When the guard variable is false' {
+
+        BeforeEach {
+            $script:__RunningInEnterAction = $false
+        }
+
+        It 'should add the action to the list' {
+            $action = { Write-Host 'action' }
+            Register-OnEnterAction -Action $action
+            $script:OnEnterActions.Count | Should -Be 1
+            $script:OnEnterActions[0] | Should -Be $action
+        }
+    }
+
+    Context 'When running inside an Enter-Build action' {
+
+        BeforeEach {
+            $script:__RunningInEnterAction = $true
+        }
+
+        It 'should not add the action to the list' {
+            Register-OnEnterAction -Action { Write-Host 'action' }
+            $script:OnEnterActions.Count | Should -Be 0
+        }
+    }
+}

--- a/module/functions/Register-OnEnterAction.ps1
+++ b/module/functions/Register-OnEnterAction.ps1
@@ -5,6 +5,7 @@
 function Register-OnEnterAction
 {
     [CmdletBinding()]
+    [OutputType([System.Void])]
     param (
         [Parameter(Mandatory)]
         [scriptblock] $Action

--- a/module/functions/Register-OnEnterAction.ps1
+++ b/module/functions/Register-OnEnterAction.ps1
@@ -1,0 +1,18 @@
+# <copyright file="Register-OnEnterAction.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+function Register-OnEnterAction
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [scriptblock] $Action
+    )
+
+    # Do not register the action if we're already running in the context of one of these actions
+    if (!(Test-Path variable:/__RunningInEnterAction) -or !$__RunningInEnterAction)
+    {
+        $script:OnEnterActions.Add($Action)
+    }
+}

--- a/module/functions/Register-OnExitAction.Tests.ps1
+++ b/module/functions/Register-OnExitAction.Tests.ps1
@@ -1,0 +1,58 @@
+# <copyright file="Register-OnExitAction.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+BeforeAll {
+    # sut
+    . $PSCommandPath.Replace('.Tests.ps1','.ps1')
+}
+
+Describe 'Register-OnExitAction' {
+
+    BeforeEach {
+        $script:OnExitActions = [System.Collections.Generic.List[scriptblock]]::new()
+        Remove-Variable -Name __RunningInExitAction -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    Context 'When the guard variable does not exist' {
+
+        It 'should add the action to the list' {
+            $action = { Write-Host 'action' }
+            Register-OnExitAction -Action $action
+            $script:OnExitActions.Count | Should -Be 1
+            $script:OnExitActions[0] | Should -Be $action
+        }
+
+        It 'can register multiple actions' {
+            Register-OnExitAction -Action { Write-Host 'action 1' }
+            Register-OnExitAction -Action { Write-Host 'action 2' }
+            $script:OnExitActions.Count | Should -Be 2
+        }
+    }
+
+    Context 'When the guard variable is false' {
+
+        BeforeEach {
+            $script:__RunningInExitAction = $false
+        }
+
+        It 'should add the action to the list' {
+            $action = { Write-Host 'action' }
+            Register-OnExitAction -Action $action
+            $script:OnExitActions.Count | Should -Be 1
+            $script:OnExitActions[0] | Should -Be $action
+        }
+    }
+
+    Context 'When running inside an Exit-Build action' {
+
+        BeforeEach {
+            $script:__RunningInExitAction = $true
+        }
+
+        It 'should not add the action to the list' {
+            Register-OnExitAction -Action { Write-Host 'action' }
+            $script:OnExitActions.Count | Should -Be 0
+        }
+    }
+}

--- a/module/functions/Register-OnExitAction.ps1
+++ b/module/functions/Register-OnExitAction.ps1
@@ -1,0 +1,18 @@
+# <copyright file="Register-OnExitAction.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+function Register-OnExitAction
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [scriptblock] $Action
+    )
+
+    # Do not register the action if we're already running in the context of one of these actions
+    if (!(Test-Path variable:/__RunningInExitAction) -or !$__RunningInExitAction)
+    {
+        $script:OnExitActions.Add($Action)
+    }
+}

--- a/module/functions/Register-OnExitAction.ps1
+++ b/module/functions/Register-OnExitAction.ps1
@@ -5,6 +5,7 @@
 function Register-OnExitAction
 {
     [CmdletBinding()]
+    [OutputType([System.Void])]
     param (
         [Parameter(Mandatory)]
         [scriptblock] $Action

--- a/module/tasks/common.tasks.ps1
+++ b/module/tasks/common.tasks.ps1
@@ -34,7 +34,7 @@ task setupModules -If { $null -ne $RequiredPowerShellModules -and $RequiredPower
 # run a nested build, thus allowing one or more Tasks to be run in this way.
 # However, to avoid recursion errors we must provide a mechanism for ZF to know when
 # it is already running in this context. When executing the actions we set a
-# well-known variable that the 'Register-On*Action' helper functions look for when
+# well-known variable that the 'Register-On*Action' helper functions look for
 # when deciding whether to do the actual registration.
 Enter-Build {
     if ($OnEnterActions.Count -gt 0) {

--- a/module/tasks/common.tasks.ps1
+++ b/module/tasks/common.tasks.ps1
@@ -27,14 +27,27 @@ task setupModules -If { $null -ne $RequiredPowerShellModules -and $RequiredPower
 # Support the special InvokeBuild entry & exit actions in a way that allows
 # extensions to register their own actions and have them run using this
 # built-in InvokeBuild functionality.  This is primarily intended to support
-# compensation scenarios in the event of terminating errors.
+# compensation scenarios in the event of terminating errors or the equivalent
+# of a 'finally' block.
+
+# These actions can be scriptblocks that perform some specific processing or they can
+# run a nested build, thus allowing one or more Tasks to be run in this way.
+# However, to avoid recursion errors we must provide a mechanism for ZF to know when
+# it is already running in this context. When executing the actions we set a
+# well-known variable that the 'Register-On*Action' helper functions look for when
+# when deciding whether to do the actual registration.
 Enter-Build {
     if ($OnEnterActions.Count -gt 0) {
         Write-Build Green "Found $($OnEnterActions.Count) registered 'Enter-Build' action(s)"
         for ($i=0; $i -lt $OnEnterActions.Count; $i++) {
             Write-Build White "Running action $i"
-            # Run action, no need to override the default 'ErrorAction' handling for the OnEnter actions
-            Invoke-Command -ScriptBlock $OnEnterActions[$i]
+            & {
+                # The invoked scriptblock will inherit this value, so this registration process
+                # and the action itself can be aware of when it is running in this context.
+                $__RunningInEnterAction = $true
+                # Run action, no need to override the default 'ErrorAction' handling for the OnEnter actions
+                Invoke-Command -ScriptBlock $OnEnterActions[$i]
+            }
         }
     }
 }
@@ -43,8 +56,13 @@ Exit-Build {
         Write-Build Green "Found $($OnExitActions.Count) registered 'Exit-Build' action(s)"
         for ($i=0; $i -lt $OnExitActions.Count; $i++) {
             Write-Build White "Running action $i"
-            # Run the action, but ensure that any remaining actions are run even if the current one fails
-            Invoke-Command -ScriptBlock $OnExitActions[$i] -ErrorAction Continue
+            & {
+                # The invoked scriptblock will inherit this value, so this registration process
+                # and the action itself can be aware of when it is running in this context.
+                $__RunningInExitAction = $true
+                # Run the action, but ensure that any remaining actions are run even if the current one fails
+                Invoke-Command -ScriptBlock $OnExitActions[$i] -ErrorAction Continue
+            }
         }
     }
 }


### PR DESCRIPTION
Previously we could only run scriptblocks for the OnEnter & OnExit actions.  This change enables running nested InvokeBuild processes allowing one or more tasks to the run as a single action.

To avoid issues with recursively registering these actions when running nested builds, the registration has been abstracted into helper functions owned by the extension (previously the downstream extension or build process was expected to manipulate the `OnEnterActions` & `OnExitActions` properties.

The updated registration mechanism is as follows:
```
Register-OnExitAction -Action { Invoke-Build -File tasks.ps1 -Task TaskThatShouldAlwaysRun }
```

When using a nested build, everything from the parent scope is available to the action.  This allows these actions, for example, to run tasks from a ZeroFailed extension whilst ensuring tasks/functions/variables from other extensions if depends on are available. However, it is important to note that tasks from extension dependencies are ***not*** available to the nested build.

***NOTE**: This is considered a breaking change due to the updated action registration mechanism.*